### PR TITLE
Implement dual-file watching and no_trailing_slash configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ bin/
 .venv
 
 settings.local.json
+configs/.*
+logs/

--- a/configs/proxy.example.yaml
+++ b/configs/proxy.example.yaml
@@ -80,6 +80,19 @@
 #   - v2.example.com
 
 # =============================================================================
+# Path Options
+# =============================================================================
+
+# By default, non-root paths redirect /route → /route/ (HTTP 301).
+# Use no_trailing_slash to disable this for specific paths.
+#
+# Values must exactly match the listener_key entries (domain + path).
+
+# no_trailing_slash:
+#   - shared.example.com/api      # /api and /api/ both work, no redirect
+#   - example.com/docs            # applies to both proxy routes and static sites
+
+# =============================================================================
 # Listener Configuration Examples
 # =============================================================================
 

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -211,6 +211,66 @@ Serve local directories as static websites.
 - Colon (`:`) in path is NOT a port separator
 - SPA support enabled if `index.html` exists
 
+## Path Options
+
+### Trailing Slash Redirect
+
+By default, sslly-nginx generates a redirect from `/route` to `/route/` for every non-root path:
+
+```nginx
+# Generated automatically for non-root paths
+location = /api {
+    return 301 $scheme://$host/api/;
+}
+location /api/ {
+    proxy_pass http://127.0.0.1:8080/;
+}
+```
+
+This ensures consistent URL canonicalization. To disable it for specific paths, add a `no_trailing_slash` list to `proxy.yaml`:
+
+```yaml
+8080:
+  - example.com/api
+  - example.com/dashboard
+
+# Disable trailing slash redirect for these paths
+no_trailing_slash:
+  - example.com/api
+```
+
+With `no_trailing_slash`, the redirect block is omitted and the location matches both `/api` and `/api/`:
+
+```nginx
+# Generated when path is in no_trailing_slash
+location /api/ {
+    proxy_pass http://127.0.0.1:8080/;
+}
+```
+
+**Rules:**
+
+- Values must exactly match the `listener_key` path entries (domain + path, e.g. `example.com/api`)
+- Applies to both proxy routes and static site routes
+- Root paths (`/`) are unaffected — they never generate a redirect regardless
+
+**Example — mixed config:**
+
+```yaml
+# API: no redirect (client sends /api or /api/, both work)
+8080:
+  - example.com/api
+
+# Admin: redirect enforced (canonical URL is /admin/)
+9090:
+  - example.com/admin
+
+no_trailing_slash:
+  - example.com/api
+```
+
+---
+
 ## Validation Rules
 
 ### Protocol Compatibility

--- a/docs/MANUAL_NGINX_EDIT.md
+++ b/docs/MANUAL_NGINX_EDIT.md
@@ -1,0 +1,69 @@
+# Manual nginx.conf Editing
+
+sslly-nginx supports two workflows for nginx.conf:
+
+1. **Managed mode** (default): `proxy.yaml` / `cors.yaml` / SSL changes trigger automatic config regeneration and reload.
+2. **Manual edit mode**: Edit either nginx.conf location; sslly-nginx detects the change, syncs both files, and reloads nginx.
+
+Both workflows coexist. When a managed reload runs after a manual edit, the manually edited file is backed up before being overwritten.
+
+---
+
+## File paths
+
+| Path | Role |
+|------|------|
+| `/etc/nginx/nginx.conf` | The file nginx actually reads. |
+| `./configs/.sslly-runtime/current/nginx/nginx.conf` | Runtime cache copy — kept in sync with `/etc/nginx/nginx.conf`. |
+| `./configs/.sslly-runtime/current/certs/` | Stable cert paths referenced inside nginx.conf. Managed by sslly-nginx; do not edit manually. |
+
+Both nginx.conf locations are equivalent for manual editing. Editing either one has the same effect.
+
+---
+
+## Behavior
+
+### Dual-file watching
+
+sslly-nginx watches both nginx.conf locations simultaneously:
+
+- `/etc/nginx/nginx.conf`
+- `./configs/.sslly-runtime/current/nginx/nginx.conf`
+
+When a manual edit is detected on either file:
+
+1. The edited content is copied to the other file (sync).
+2. `nginx -t` is run to validate the config.
+3. If valid: nginx is reloaded (SIGHUP).
+4. If invalid: an error is logged; the previous good config is restored to both files and nginx is reloaded.
+
+Changes written by sslly-nginx itself are ignored — only external edits trigger this path.
+
+### Loop prevention
+
+Writing to either file sets a `suppressUntil = now + 2s` timestamp. Both watchers ignore events that arrive within this window, preventing a sync write from triggering a second reload.
+
+### Re-registration after snapshot activation
+
+`./configs/.sslly-runtime/current/` is replaced atomically on every managed reload via `os.Rename`. After each activation, the runtime nginx.conf watcher is re-registered against the new file inode. The `/etc/nginx/nginx.conf` watcher is unaffected (stable path).
+
+### Backing up manually edited nginx.conf
+
+When a managed reload runs and the current `/etc/nginx/nginx.conf` differs from the last generated config, sslly-nginx backs up the manually edited file before overwriting it.
+
+Backup location:
+```
+./configs/.sslly-backups/manual-nginx-<timestamp>.conf
+```
+
+---
+
+## Implementation
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `internal/app/app.go` | Add `runtimeNginxWatcher *fsnotify.Watcher`, `suppressNginxWatchUntil time.Time`, `suppressNginxMu sync.Mutex`; stop watcher in `Stop()` |
+| `internal/app/watchers.go` | Add watcher for `/etc/nginx/nginx.conf`; add `reRegisterRuntimeNginxWatcher()`; add `handleNginxConfEdit(src, dst)` for bidirectional sync |
+| `internal/app/reload.go` | Set suppress timestamp before writing either file; call `reRegisterRuntimeNginxWatcher()` after `activateRuntimeSnapshot()`; back up manual edits before overwrite |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/hnrobert/sslly-nginx/internal/backup"
 	"github.com/hnrobert/sslly-nginx/internal/config"
 	"github.com/hnrobert/sslly-nginx/internal/logger"
@@ -21,16 +22,21 @@ const (
 )
 
 type App struct {
-	configWatcher *watcher.Watcher
-	sslWatcher    *watcher.Watcher
-	config        *config.Config
-	nginxManager  *nginx.Manager
-	lastGoodConf  string
-	activeCertMap map[string]ssl.Certificate
-	sslReport     ssl.ScanReport
-	backupManager *backup.Manager
-	staticSites   map[string]*runningStaticSite
-	reloadMu      sync.Mutex
+	configWatcher       *watcher.Watcher
+	sslWatcher          *watcher.Watcher
+	runtimeNginxWatcher *fsnotify.Watcher
+	config              *config.Config
+	nginxManager        *nginx.Manager
+	lastGoodConf        string
+	activeCertMap       map[string]ssl.Certificate
+	sslReport           ssl.ScanReport
+	backupManager       *backup.Manager
+	staticSites         map[string]*runningStaticSite
+	reloadMu            sync.Mutex
+
+	// suppress nginx.conf watchers for 2s after a programmatic write
+	suppressNginxMu         sync.Mutex
+	suppressNginxWatchUntil time.Time
 
 	reloadDebounceMu    sync.Mutex
 	reloadDebounceTimer *time.Timer
@@ -138,6 +144,9 @@ func (a *App) Stop() {
 	}
 	if a.sslWatcher != nil {
 		a.sslWatcher.Stop()
+	}
+	if a.runtimeNginxWatcher != nil {
+		a.runtimeNginxWatcher.Close()
 	}
 	a.stopAllStaticSites()
 	a.reloadDebounceMu.Lock()

--- a/internal/app/reload.go
+++ b/internal/app/reload.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/hnrobert/sslly-nginx/internal/backup"
 	"github.com/hnrobert/sslly-nginx/internal/config"
 	"github.com/hnrobert/sslly-nginx/internal/logger"
 	"github.com/hnrobert/sslly-nginx/internal/nginx"
@@ -86,6 +87,27 @@ func (a *App) reload(snapshotID string) error {
 	if err := activateRuntimeSnapshot(snapshotID); err != nil {
 		return fmt.Errorf("failed to activate runtime snapshot: %w", err)
 	}
+	// Re-register runtime nginx.conf watcher — current/ was replaced by rename.
+	if err := a.reRegisterRuntimeNginxWatcher(); err != nil {
+		logger.Warn("failed to re-register runtime nginx.conf watcher: %v", err)
+	}
+
+	// Back up manually edited nginx.conf before overwriting.
+	if existing, err := os.ReadFile(nginxConf); err == nil {
+		if a.lastGoodConf != "" && string(existing) != a.lastGoodConf {
+			ts := time.Now().UTC().Format("20060102T150405.000000000Z")
+			bkDir := backup.DefaultBackupRoot(configDir)
+			backupPath := bkDir + "/manual-nginx-" + ts + ".conf"
+			if err := os.MkdirAll(bkDir, 0755); err == nil {
+				if err := os.WriteFile(backupPath, existing, 0644); err == nil {
+					logger.Info("Backed up manually edited nginx.conf to %s", backupPath)
+				}
+			}
+		}
+	}
+
+	// Suppress nginx.conf watchers before writing.
+	a.suppressNginxWatch()
 
 	// Write nginx configuration
 	if err := os.WriteFile(nginxConf, []byte(nginxConfig), 0644); err != nil {

--- a/internal/app/watchers.go
+++ b/internal/app/watchers.go
@@ -87,14 +87,18 @@ func (a *App) setupWatchers() error {
 		}
 	}()
 
-	// Watch /etc/nginx/nginx.conf for manual edits
+	// Watch /etc/nginx/ directory for manual edits to nginx.conf.
+	// Watching the directory (not the file) is required because editors often
+	// use atomic writes (write temp + rename), which changes the inode and
+	// breaks file-level inotify watches.
+	etcNginxDir := filepath.Dir(nginxConf)
 	etcWatcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return fmt.Errorf("failed to create nginx.conf watcher: %w", err)
 	}
-	if err := etcWatcher.Add(nginxConf); err != nil {
+	if err := etcWatcher.Add(etcNginxDir); err != nil {
 		etcWatcher.Close()
-		logger.Warn("Could not watch %s: %v", nginxConf, err)
+		logger.Warn("Could not watch %s: %v", etcNginxDir, err)
 	} else {
 		go func() {
 			for {
@@ -103,8 +107,12 @@ func (a *App) setupWatchers() error {
 					if !ok {
 						return
 					}
+					if filepath.Base(event.Name) != "nginx.conf" {
+						continue
+					}
 					if event.Op&fsnotify.Write == fsnotify.Write ||
-						event.Op&fsnotify.Create == fsnotify.Create {
+						event.Op&fsnotify.Create == fsnotify.Create ||
+						event.Op&fsnotify.Rename == fsnotify.Rename {
 						if a.isNginxWatchSuppressed() {
 							continue
 						}
@@ -133,15 +141,16 @@ func (a *App) setupWatchers() error {
 // reRegisterRuntimeNginxWatcher closes any existing runtime nginx.conf watcher
 // and creates a new one. Called after each activateRuntimeSnapshot because the
 // current/ directory is replaced by rename, invalidating the previous inode.
+// Watches the directory (not the file) to survive atomic editor writes.
 func (a *App) reRegisterRuntimeNginxWatcher() error {
 	if a.runtimeNginxWatcher != nil {
 		a.runtimeNginxWatcher.Close()
 		a.runtimeNginxWatcher = nil
 	}
 
-	runtimeConf := runtimeNginxConfPath()
-	if _, err := os.Stat(runtimeConf); err != nil {
-		// File doesn't exist yet; will be registered on next snapshot activation.
+	runtimeNginxDir := filepath.Dir(runtimeNginxConfPath())
+	if _, err := os.Stat(runtimeNginxDir); err != nil {
+		// Directory doesn't exist yet; will be registered on next snapshot activation.
 		return nil
 	}
 
@@ -149,7 +158,7 @@ func (a *App) reRegisterRuntimeNginxWatcher() error {
 	if err != nil {
 		return err
 	}
-	if err := w.Add(runtimeConf); err != nil {
+	if err := w.Add(runtimeNginxDir); err != nil {
 		w.Close()
 		return err
 	}
@@ -162,12 +171,17 @@ func (a *App) reRegisterRuntimeNginxWatcher() error {
 				if !ok {
 					return
 				}
+				if filepath.Base(event.Name) != "nginx.conf" {
+					continue
+				}
 				if event.Op&fsnotify.Write == fsnotify.Write ||
-					event.Op&fsnotify.Create == fsnotify.Create {
+					event.Op&fsnotify.Create == fsnotify.Create ||
+					event.Op&fsnotify.Rename == fsnotify.Rename {
 					if a.isNginxWatchSuppressed() {
 						continue
 					}
 					logger.Info("Manual edit detected: %s", event.Name)
+					runtimeConf := runtimeNginxConfPath()
 					a.handleNginxConfEdit(runtimeConf, nginxConf)
 				}
 			case err, ok := <-w.Errors:

--- a/internal/app/watchers.go
+++ b/internal/app/watchers.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -86,7 +87,152 @@ func (a *App) setupWatchers() error {
 		}
 	}()
 
+	// Watch /etc/nginx/nginx.conf for manual edits
+	etcWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create nginx.conf watcher: %w", err)
+	}
+	if err := etcWatcher.Add(nginxConf); err != nil {
+		etcWatcher.Close()
+		logger.Warn("Could not watch %s: %v", nginxConf, err)
+	} else {
+		go func() {
+			for {
+				select {
+				case event, ok := <-etcWatcher.Events:
+					if !ok {
+						return
+					}
+					if event.Op&fsnotify.Write == fsnotify.Write ||
+						event.Op&fsnotify.Create == fsnotify.Create {
+						if a.isNginxWatchSuppressed() {
+							continue
+						}
+						logger.Info("Manual edit detected: %s", event.Name)
+						runtimeConf := runtimeNginxConfPath()
+						a.handleNginxConfEdit(nginxConf, runtimeConf)
+					}
+				case err, ok := <-etcWatcher.Errors:
+					if !ok {
+						return
+					}
+					logger.Error("nginx.conf watcher error: %v", err)
+				}
+			}
+		}()
+	}
+
+	// Watch runtime nginx.conf for manual edits
+	if err := a.reRegisterRuntimeNginxWatcher(); err != nil {
+		logger.Warn("Could not watch runtime nginx.conf: %v", err)
+	}
+
 	return nil
+}
+
+// reRegisterRuntimeNginxWatcher closes any existing runtime nginx.conf watcher
+// and creates a new one. Called after each activateRuntimeSnapshot because the
+// current/ directory is replaced by rename, invalidating the previous inode.
+func (a *App) reRegisterRuntimeNginxWatcher() error {
+	if a.runtimeNginxWatcher != nil {
+		a.runtimeNginxWatcher.Close()
+		a.runtimeNginxWatcher = nil
+	}
+
+	runtimeConf := runtimeNginxConfPath()
+	if _, err := os.Stat(runtimeConf); err != nil {
+		// File doesn't exist yet; will be registered on next snapshot activation.
+		return nil
+	}
+
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	if err := w.Add(runtimeConf); err != nil {
+		w.Close()
+		return err
+	}
+	a.runtimeNginxWatcher = w
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-w.Events:
+				if !ok {
+					return
+				}
+				if event.Op&fsnotify.Write == fsnotify.Write ||
+					event.Op&fsnotify.Create == fsnotify.Create {
+					if a.isNginxWatchSuppressed() {
+						continue
+					}
+					logger.Info("Manual edit detected: %s", event.Name)
+					a.handleNginxConfEdit(runtimeConf, nginxConf)
+				}
+			case err, ok := <-w.Errors:
+				if !ok {
+					return
+				}
+				logger.Error("runtime nginx.conf watcher error: %v", err)
+			}
+		}
+	}()
+
+	return nil
+}
+
+// runtimeNginxConfPath returns the absolute path to the runtime nginx.conf.
+func runtimeNginxConfPath() string {
+	abs, err := filepath.Abs(filepath.Join(runtimeDir, "current", "nginx", "nginx.conf"))
+	if err != nil {
+		return filepath.Join(runtimeDir, "current", "nginx", "nginx.conf")
+	}
+	return abs
+}
+
+// suppressNginxWatch marks both nginx.conf watchers to ignore events for 2s.
+func (a *App) suppressNginxWatch() {
+	a.suppressNginxMu.Lock()
+	a.suppressNginxWatchUntil = time.Now().Add(2 * time.Second)
+	a.suppressNginxMu.Unlock()
+}
+
+func (a *App) isNginxWatchSuppressed() bool {
+	a.suppressNginxMu.Lock()
+	defer a.suppressNginxMu.Unlock()
+	return time.Now().Before(a.suppressNginxWatchUntil)
+}
+
+// handleNginxConfEdit handles a manual edit on src: syncs to dst, validates, reloads.
+func (a *App) handleNginxConfEdit(src, dst string) {
+	a.reloadMu.Lock()
+	defer a.reloadMu.Unlock()
+
+	data, err := os.ReadFile(src)
+	if err != nil {
+		logger.Error("Failed to read %s: %v", src, err)
+		return
+	}
+
+	// Suppress watchers before writing to dst.
+	a.suppressNginxWatch()
+	if err := os.WriteFile(dst, data, 0644); err != nil {
+		logger.Error("Failed to sync nginx.conf to %s: %v", dst, err)
+		return
+	}
+
+	if err := a.nginxManager.Reload(); err != nil {
+		logger.Error("nginx reload failed after manual edit: %v", err)
+		a.restoreGoodConfiguration()
+		if err := a.nginxManager.Reload(); err != nil {
+			logger.Error("Failed to restore nginx after bad manual edit: %v", err)
+		}
+		return
+	}
+
+	a.saveGoodConfiguration()
+	logger.Info("nginx reloaded from manual edit of %s", src)
 }
 
 func (a *App) scheduleReload() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,9 +103,10 @@ func (p Protocol) IsStatic() bool {
 }
 
 type Config struct {
-	Log   LogConfig             `yaml:"log"`
-	CORS  map[string]CORSConfig `yaml:"cors"`
-	Ports map[string][]string   `yaml:",inline"`
+	Log             LogConfig             `yaml:"log"`
+	CORS            map[string]CORSConfig `yaml:"cors"`
+	NoTrailingSlash []string              `yaml:"no_trailing_slash"`
+	Ports           map[string][]string   `yaml:",inline"`
 
 	// RuntimeStaticSites stores static site information for nginx config generation.
 	// Key is the original config key (e.g., "/app/static" or "[/app/static]/route").
@@ -428,6 +429,7 @@ func Load(configDir string) (*Config, error) {
 	// Defensive: do not allow these keys to appear as ports.
 	delete(config.Ports, "cors")
 	delete(config.Ports, "log")
+	delete(config.Ports, "no_trailing_slash")
 
 	if len(config.Ports) == 0 {
 		return nil, fmt.Errorf("config is empty or invalid (%s has no proxy mappings)", proxyConfigFile)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,8 +1,38 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
+
+func TestLoad_NoTrailingSlash(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	proxyYAML := `8080:
+  - example.com/api
+  - example.com/admin
+
+no_trailing_slash:
+  - example.com/api
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "proxy.yaml"), []byte(proxyYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(tmpDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if len(cfg.NoTrailingSlash) != 1 || cfg.NoTrailingSlash[0] != "example.com/api" {
+		t.Errorf("unexpected NoTrailingSlash: %v", cfg.NoTrailingSlash)
+	}
+
+	if _, ok := cfg.Ports["no_trailing_slash"]; ok {
+		t.Error("no_trailing_slash should not appear in Ports map")
+	}
+}
 
 func TestParseStaticSiteKey(t *testing.T) {
 	tests := []struct {

--- a/internal/nginx/nginx.go
+++ b/internal/nginx/nginx.go
@@ -224,6 +224,12 @@ func formatUpstreamAddr(upstream config.Upstream) string {
 }
 
 func GenerateConfig(cfg *config.Config, certMap map[string]ssl.Certificate) string {
+	// Build a set of paths that should not have trailing slash redirects.
+	noTrailingSlash := make(map[string]bool, len(cfg.NoTrailingSlash))
+	for _, p := range cfg.NoTrailingSlash {
+		noTrailingSlash[p] = true
+	}
+
 	var sb strings.Builder
 
 	// Read ports from environment with sensible defaults
@@ -502,12 +508,12 @@ events {
 
 			// Generate location blocks for static sites
 			if len(staticSiteRoutes) > 0 {
-				generateStaticSiteLocations(&sb, staticSiteRoutes, corsConfig)
+				generateStaticSiteLocations(&sb, staticSiteRoutes, corsConfig, noTrailingSlash)
 			}
 
 			// Generate location blocks for proxy routes
 			if len(routes) > 0 {
-				generateProxyLocations(&sb, routes, corsConfig)
+				generateProxyLocations(&sb, routes, corsConfig, noTrailingSlash)
 			}
 
 			sb.WriteString(`    }
@@ -532,12 +538,12 @@ events {
 
 		// Generate location blocks for static sites
 		if len(staticSiteRoutes) > 0 {
-			generateStaticSiteLocations(&sb, staticSiteRoutes, corsConfig)
+			generateStaticSiteLocations(&sb, staticSiteRoutes, corsConfig, noTrailingSlash)
 		}
 
 		// Generate location blocks for proxy routes
 		if len(routes) > 0 {
-			generateProxyLocations(&sb, routes, corsConfig)
+			generateProxyLocations(&sb, routes, corsConfig, noTrailingSlash)
 		}
 
 		sb.WriteString(`    }
@@ -552,7 +558,7 @@ events {
 
 // generateStaticSiteLocations generates nginx location blocks for static sites
 // Uses root directive for "/" path, alias directive for non-root paths
-func generateStaticSiteLocations(sb *strings.Builder, routes []StaticRouteConfig, corsConfig *config.CORSConfig) {
+func generateStaticSiteLocations(sb *strings.Builder, routes []StaticRouteConfig, corsConfig *config.CORSConfig, noTrailingSlash map[string]bool) {
 	corsHeaders := generateCORSHeaders(corsConfig)
 
 	// Sort routes by path length (longest first)
@@ -591,12 +597,14 @@ func generateStaticSiteLocations(sb *strings.Builder, routes []StaticRouteConfig
 			}
 		} else {
 			// Non-root path: use alias directive
-			// Add redirect for path without trailing slash
-			sb.WriteString(fmt.Sprintf(`        location = %s {
+			// Add redirect for path without trailing slash (unless disabled)
+			if !noTrailingSlash[route.DomainPath] {
+				sb.WriteString(fmt.Sprintf(`        location = %s {
             return 301 $scheme://$host%s/;
         }
 
 `, locationPath, locationPath))
+			}
 
 			// Ensure alias path ends with /
 			aliasPath := route.StaticSite.Dir
@@ -632,7 +640,7 @@ func generateStaticSiteLocations(sb *strings.Builder, routes []StaticRouteConfig
 }
 
 // generateProxyLocations generates nginx location blocks for proxy routes
-func generateProxyLocations(sb *strings.Builder, routes []RouteConfig, corsConfig *config.CORSConfig) {
+func generateProxyLocations(sb *strings.Builder, routes []RouteConfig, corsConfig *config.CORSConfig, noTrailingSlash map[string]bool) {
 	corsHeaders := generateCORSHeaders(corsConfig)
 
 	// Sort routes by path length (longest first)
@@ -650,13 +658,15 @@ func generateProxyLocations(sb *strings.Builder, routes []RouteConfig, corsConfi
 			proxyPass += route.Upstream.Path
 		}
 
-		// For non-root paths, add redirect and use trailing slash
+		// For non-root paths, optionally add redirect and use trailing slash
 		if locationPath != "/" {
-			sb.WriteString(fmt.Sprintf(`        location = %s {
+			if !noTrailingSlash[route.DomainPath] {
+				sb.WriteString(fmt.Sprintf(`        location = %s {
             return 301 $scheme://$host%s/;
         }
 
 `, locationPath, locationPath))
+			}
 			locationPath = locationPath + "/"
 			if !strings.HasSuffix(proxyPass, "/") {
 				proxyPass += "/"

--- a/internal/nginx/nginx_test.go
+++ b/internal/nginx/nginx_test.go
@@ -188,6 +188,96 @@ func TestGenerateConfig_StaticSitesWithProxy(t *testing.T) {
 	}
 }
 
+func TestGenerateConfig_NoTrailingSlash_ProxyRoute(t *testing.T) {
+	cfg := &config.Config{
+		CORS: map[string]config.CORSConfig{},
+		Ports: map[string][]string{
+			"8080": {"example.com/api"},
+		},
+		NoTrailingSlash: []string{"example.com/api"},
+	}
+
+	ng := GenerateConfig(cfg, map[string]ssl.Certificate{})
+
+	if strings.Contains(ng, "location = /api") {
+		t.Error("no_trailing_slash: redirect block should not be generated for example.com/api")
+	}
+	if !strings.Contains(ng, "location /api/") {
+		t.Error("proxy location /api/ should still be present")
+	}
+}
+
+func TestGenerateConfig_DefaultTrailingSlash_ProxyRoute(t *testing.T) {
+	cfg := &config.Config{
+		CORS: map[string]config.CORSConfig{},
+		Ports: map[string][]string{
+			"8080": {"example.com/api"},
+		},
+	}
+
+	ng := GenerateConfig(cfg, map[string]ssl.Certificate{})
+
+	if !strings.Contains(ng, "location = /api") {
+		t.Error("default: redirect block should be generated for /api")
+	}
+	if !strings.Contains(ng, "return 301 $scheme://$host/api/") {
+		t.Error("default: 301 redirect to /api/ should be present")
+	}
+}
+
+func TestGenerateConfig_NoTrailingSlash_StaticSite(t *testing.T) {
+	tmpDir := t.TempDir()
+	staticDir := filepath.Join(tmpDir, "static")
+	if err := os.MkdirAll(staticDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Ports: map[string][]string{
+			staticDir: {"example.com/docs"},
+		},
+		RuntimeStaticSites: map[string]config.StaticSiteSpec{
+			staticDir: {Dir: staticDir},
+		},
+		NoTrailingSlash: []string{"example.com/docs"},
+	}
+
+	ng := GenerateConfig(cfg, nil)
+
+	if strings.Contains(ng, "location = /docs") {
+		t.Error("no_trailing_slash: redirect block should not be generated for example.com/docs")
+	}
+	if !strings.Contains(ng, "location /docs/") {
+		t.Error("alias location /docs/ should still be present")
+	}
+}
+
+func TestGenerateConfig_DefaultTrailingSlash_StaticSite(t *testing.T) {
+	tmpDir := t.TempDir()
+	staticDir := filepath.Join(tmpDir, "static")
+	if err := os.MkdirAll(staticDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Ports: map[string][]string{
+			staticDir: {"example.com/docs"},
+		},
+		RuntimeStaticSites: map[string]config.StaticSiteSpec{
+			staticDir: {Dir: staticDir},
+		},
+	}
+
+	ng := GenerateConfig(cfg, nil)
+
+	if !strings.Contains(ng, "location = /docs") {
+		t.Error("default: redirect block should be generated for /docs")
+	}
+	if !strings.Contains(ng, "return 301 $scheme://$host/docs/") {
+		t.Error("default: 301 redirect to /docs/ should be present")
+	}
+}
+
 func TestGenerateConfig_StaticSitesNoIndex(t *testing.T) {
 	// Create temporary directory without index.html
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Enhance the nginx configuration management by introducing dual-file watching for manual edits and a new `no_trailing_slash` option to control trailing slash redirects for specific paths. Update documentation and tests to reflect these changes.