### PR TITLE
Enhance CORS configuration handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
         "GOMODCACHE",
         "GOOS",
         "homeassistant",
+        "ibuduan",
         "installsuffix",
         "Jellyfin",
         "keyout",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "Buildx",
         "cacheprep",
         "chowns",
+        "clearable",
         "codepoint",
         "colored",
         "colors",

--- a/docs/CORS.md
+++ b/docs/CORS.md
@@ -79,7 +79,37 @@ You can also configure CORS for specific domains:
   max_age: 86400 # 1 day
 ```
 
+### Wildcard Matching & Precedence
+
+CORS keys support three forms:
+
+| Form             | Example              | Matches                                                                                        |
+| ---------------- | -------------------- | ---------------------------------------------------------------------------------------------- |
+| Exact domain     | `api.example.com`    | Only `api.example.com`                                                                         |
+| Suffix wildcard  | `*.example.com`      | Any subdomain (`api.example.com`, `app.api.example.com`) — **not** the bare apex `example.com` |
+| Catch-all        | `*`                  | Every domain                                                                                   |
+
+When multiple keys match a domain, the **most specific** wins, in this order:
+
+1. Exact domain match
+2. **Longest** matching `*.suffix` (e.g. `*.api.example.com` wins over `*.example.com`)
+3. The `*` catch-all
+
+```yaml
+# Resolution for api.cpu.ibuduan.com (most specific wins):
+'api.cpu.ibuduan.com': { allow_origin: 'https://app.ibuduan.com' }   # 1. exact — wins
+'*.cpu.ibuduan.com':   { allow_origin: 'https://cpu.ibuduan.com' }   # 2. longer suffix
+'*.ibuduan.com':       { allow_origin: '*' }                          # 3. shorter suffix
+'*':                   { allow_origin: '*' }                          # 4. catch-all
+```
+
+> **Note:** A `*.suffix` key matches subdomains only. `*.example.com` will **not** match the bare apex `example.com` — add an exact `example.com` key for that.
+
+This mirrors how TLS certificates are matched (see `FindCertificate`).
+
 ## Generated Nginx Configuration
+
+> **Ordering:** Nginx server blocks are emitted in the declaration order of `proxy.yaml` (top-level key order, then each key's domain list in order). The output is deterministic across reloads.
 
 The CORS configuration generates appropriate Nginx headers. Example output:
 

--- a/docs/CORS.md
+++ b/docs/CORS.md
@@ -107,6 +107,48 @@ When multiple keys match a domain, the **most specific** wins, in this order:
 
 This mirrors how TLS certificates are matched (see `FindCertificate`).
 
+### Layer Inheritance & Clearing
+
+Matching layers are merged field-by-field from the least to the most specific
+(`*` → `*.suffix` shortest → longest → exact). A field you **don't** mention in
+a more specific key is **inherited** from the lower-priority layers, so a
+per-domain entry only needs to state what differs:
+
+```yaml
+'*':
+  allow_origin: '*'
+  allow_methods: [GET, POST]
+  allow_headers: [Content-Type]
+
+'api.example.com':
+  allow_credentials: true   # only this field overrides; the rest is inherited
+```
+
+To **suppress** a header that a lower layer would otherwise emit, set it to an
+empty value (`""` or `null`). An explicitly-empty field is *cleared* — the
+corresponding header is omitted entirely from that domain's server block:
+
+```yaml
+'*':
+  allow_origin: '*'
+  allow_methods: [GET, POST]
+  allow_headers: [Content-Type]
+
+'api.example.com':
+  allow_origin: ''   # ← Access-Control-Allow-Origin is OMITTED for this domain
+                     #   methods (GET, POST) and headers (Content-Type) are inherited
+```
+
+| Field state in the winning layer(s) | Resulting header                         |
+| ----------------------------------- | ---------------------------------------- |
+| Set to a value                      | Emitted with that value                  |
+| Not set in any matching layer       | Inherited, or the built-in default       |
+| Explicitly `""` or `null`           | **Omitted** (cleared)                    |
+
+This applies to `allow_origin`, `allow_methods`, `allow_headers`, and
+`expose_headers`. `max_age` and `allow_credentials` are not clearable (set them
+to the value you want, or omit to inherit/default).
+
 ## Generated Nginx Configuration
 
 > **Ordering:** Nginx server blocks are emitted in the declaration order of `proxy.yaml` (top-level key order, then each key's domain list in order). The output is deterministic across reloads.

--- a/docs/CORS.md
+++ b/docs/CORS.md
@@ -157,7 +157,6 @@ The CORS configuration generates appropriate Nginx headers. Example output:
 
 ```conf
 # CORS configuration
-add_header 'Access-Control-Allow-Origin' '*' always;
 add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE' always;
 add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
 add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
@@ -175,6 +174,18 @@ if ($request_method = 'OPTIONS') {
 }
 
 ```
+
+> **Why `Access-Control-Allow-Origin` appears only in the OPTIONS block:**
+> Many proxied backends already set this header on actual responses. Adding it
+> again at the location level produces a *duplicate* `Access-Control-Allow-Origin`,
+> which browsers reject with `Access-Control-Allow-Origin cannot contain more than
+> one origin`. So nginx emits `Access-Control-Allow-Origin` only inside the OPTIONS
+> preflight block, where `return 204` short-circuits before `proxy_pass` and the
+> backend is never reached (exactly one Origin). `Allow-Methods` / `Allow-Headers` /
+> `Expose-Headers` stay at the location level because backends typically don't set
+> those. If your backend does **not** send `Access-Control-Allow-Origin` on actual
+> requests, cross-origin actual requests will lack the header — handle CORS in the
+> backend, or strip it with `proxy_hide_header` so nginx owns it fully.
 
 ## Important Notes
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,12 @@ type Config struct {
 	NoTrailingSlash []string              `yaml:"no_trailing_slash"`
 	Ports           map[string][]string   `yaml:",inline"`
 
+	// OrderedPorts holds the top-level proxy.yaml mapping keys in their file
+	// order (excluding the special cors/log/no_trailing_slash keys). It is
+	// used to emit nginx server blocks deterministically, in declaration order.
+	// Runtime-only (not persisted to YAML).
+	OrderedPorts []string `yaml:"-"`
+
 	// RuntimeStaticSites stores static site information for nginx config generation.
 	// Key is the original config key (e.g., "/app/static" or "[/app/static]/route").
 	// It is runtime-only (not persisted to YAML).
@@ -406,6 +412,12 @@ func Load(configDir string) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse %s: %w", proxyConfigFile, err)
 	}
 
+	// Capture top-level proxy.yaml key order so nginx server blocks can be
+	// emitted deterministically in declaration order.
+	if keys, err := orderedTopLevelKeys(proxyData); err == nil {
+		config.OrderedPorts = keys
+	}
+
 	// Load optional logs config (content is the inner object, without outer 'log:')
 	logsPath := filepath.Join(configDir, logsConfigFile)
 	if data, err := os.ReadFile(logsPath); err == nil {
@@ -431,11 +443,41 @@ func Load(configDir string) (*Config, error) {
 	delete(config.Ports, "log")
 	delete(config.Ports, "no_trailing_slash")
 
+	// Keep only keys that remain valid ports (drops cors/log/no_trailing_slash
+	// and any key not present in Ports), preserving file order.
+	var kept []string
+	for _, k := range config.OrderedPorts {
+		if _, ok := config.Ports[k]; ok {
+			kept = append(kept, k)
+		}
+	}
+	config.OrderedPorts = kept
+
 	if len(config.Ports) == 0 {
 		return nil, fmt.Errorf("config is empty or invalid (%s has no proxy mappings)", proxyConfigFile)
 	}
 
 	return &config, nil
+}
+
+// orderedTopLevelKeys returns the top-level mapping keys of a YAML document in
+// their file order. Non-mapping documents return nil.
+func orderedTopLevelKeys(data []byte) ([]string, error) {
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return nil, err
+	}
+	if len(node.Content) == 0 || node.Content[0].Kind != yaml.MappingNode {
+		return nil, nil
+	}
+	mapping := node.Content[0]
+	var keys []string
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Kind == yaml.ScalarNode {
+			keys = append(keys, mapping.Content[i].Value)
+		}
+	}
+	return keys, nil
 }
 
 // Prepare ensures the configuration directory is ready for loading:
@@ -677,20 +719,6 @@ func ensureFileFromExample(configDir, filename, exampleFilename string) error {
 
 	// Optional files: keep behaviour of ensuring they exist.
 	return os.WriteFile(dst, []byte{}, 0666)
-}
-
-func writeYAMLFile(path string, v any) error {
-	data, err := yaml.Marshal(v)
-	if err != nil {
-		return fmt.Errorf("failed to marshal yaml for %s: %w", filepath.Base(path), err)
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
-		return fmt.Errorf("failed to create config dir for %s: %w", filepath.Base(path), err)
-	}
-	if err := os.WriteFile(path, data, 0666); err != nil {
-		return fmt.Errorf("failed to write %s: %w", filepath.Base(path), err)
-	}
-	return nil
 }
 
 func fileExists(path string) bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,7 +43,14 @@ func exampleDir() string {
 	return exampleDirDefault
 }
 
-// CORSConfig represents CORS configuration for a domain or wildcard
+// CORSConfig represents CORS configuration for a domain or wildcard.
+//
+// Fields are merged across matching layers (see nginx.getCORSConfig): a field
+// absent from a higher-priority layer is inherited from lower-priority layers,
+// while a field explicitly set to an empty value ("", null, or []) clears
+// (omits) that header. The "explicitly set" state is tracked per field via the
+// unexported present struct (populated by UnmarshalYAML) and exposed through
+// Presence/SetPresence.
 type CORSConfig struct {
 	AllowOrigin      string   `yaml:"allow_origin"`      // Access-Control-Allow-Origin (default: "*")
 	AllowMethods     []string `yaml:"allow_methods"`     // Access-Control-Allow-Methods
@@ -51,6 +58,72 @@ type CORSConfig struct {
 	ExposeHeaders    []string `yaml:"expose_headers"`    // Access-Control-Expose-Headers
 	MaxAge           int      `yaml:"max_age"`           // Access-Control-Max-Age in seconds (default: 1728000)
 	AllowCredentials bool     `yaml:"allow_credentials"` // Access-Control-Allow-Credentials (default: false)
+
+	present CORSFieldPresence `yaml:"-"`
+}
+
+// CORSFieldPresence records which CORSConfig fields were explicitly set in a
+// YAML layer. It drives field-level merge inheritance.
+type CORSFieldPresence struct {
+	AllowOrigin      bool
+	AllowMethods     bool
+	AllowHeaders     bool
+	ExposeHeaders    bool
+	MaxAge           bool
+	AllowCredentials bool
+}
+
+// Presence reports which fields were explicitly set on this config.
+func (c CORSConfig) Presence() CORSFieldPresence { return c.present }
+
+// SetPresence marks which fields are explicitly set. Used when constructing a
+// merged CORSConfig programmatically.
+func (c *CORSConfig) SetPresence(p CORSFieldPresence) { c.present = p }
+
+// UnmarshalYAML decodes a CORSConfig and records which mapping keys were
+// explicitly present (treating null and "" values as present-and-cleared, so
+// they override inherited values and clear the corresponding header).
+func (c *CORSConfig) UnmarshalYAML(value *yaml.Node) error {
+	type plain struct {
+		AllowOrigin      string   `yaml:"allow_origin"`
+		AllowMethods     []string `yaml:"allow_methods"`
+		AllowHeaders     []string `yaml:"allow_headers"`
+		ExposeHeaders    []string `yaml:"expose_headers"`
+		MaxAge           int      `yaml:"max_age"`
+		AllowCredentials bool     `yaml:"allow_credentials"`
+	}
+	var p plain
+	if err := value.Decode(&p); err != nil {
+		return err
+	}
+	c.AllowOrigin = p.AllowOrigin
+	c.AllowMethods = p.AllowMethods
+	c.AllowHeaders = p.AllowHeaders
+	c.ExposeHeaders = p.ExposeHeaders
+	c.MaxAge = p.MaxAge
+	c.AllowCredentials = p.AllowCredentials
+
+	// A null value still produces a present key in the mapping node, so both
+	// `allow_origin:` (null) and `allow_origin: ""` mark the field as set.
+	if value.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(value.Content); i += 2 {
+			switch value.Content[i].Value {
+			case "allow_origin":
+				c.present.AllowOrigin = true
+			case "allow_methods":
+				c.present.AllowMethods = true
+			case "allow_headers":
+				c.present.AllowHeaders = true
+			case "expose_headers":
+				c.present.ExposeHeaders = true
+			case "max_age":
+				c.present.MaxAge = true
+			case "allow_credentials":
+				c.present.AllowCredentials = true
+			}
+		}
+	}
+	return nil
 }
 
 // LogLevelConfig represents log level configuration for a component

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,6 +34,62 @@ no_trailing_slash:
 	}
 }
 
+func TestLoad_OrderedPorts(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Intentionally non-sorted: 9090, 8080, 7070, with special keys interspersed.
+	proxyYAML := `9090:
+  - d.example.com
+
+cors:
+  api.example.com:
+    allow_origin: "*"
+
+8080:
+  - b.example.com
+  - a.example.com
+
+log:
+  format: text
+
+7070:
+  - c.example.com
+
+no_trailing_slash:
+  - b.example.com
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "proxy.yaml"), []byte(proxyYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(tmpDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	want := []string{"9090", "8080", "7070"}
+	if len(cfg.OrderedPorts) != len(want) {
+		t.Fatalf("OrderedPorts = %v, want %v", cfg.OrderedPorts, want)
+	}
+	for i, k := range want {
+		if cfg.OrderedPorts[i] != k {
+			t.Fatalf("OrderedPorts = %v, want %v at index %d", cfg.OrderedPorts, want, i)
+		}
+	}
+
+	// Special keys must not survive into OrderedPorts (nor Ports).
+	for _, special := range []string{"cors", "log", "no_trailing_slash"} {
+		if _, ok := cfg.Ports[special]; ok {
+			t.Errorf("%q should not be in Ports", special)
+		}
+		for _, k := range cfg.OrderedPorts {
+			if k == special {
+				t.Errorf("%q should not be in OrderedPorts", special)
+			}
+		}
+	}
+}
+
 func TestParseStaticSiteKey(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/nginx/nginx.go
+++ b/internal/nginx/nginx.go
@@ -112,15 +112,16 @@ func (m *Manager) CheckHealth() error {
 	return nil
 }
 
-// getCORSConfig returns the CORS configuration for a given domain
+// getCORSConfig returns the CORS configuration for a given domain.
+// A domain-specific entry takes precedence over the "*" wildcard.
 func getCORSConfig(cfg *config.Config, domain string) *config.CORSConfig {
-	// Check for wildcard first
-	if corsConfig, ok := cfg.CORS["*"]; ok {
+	// Check for exact domain match first (most specific wins)
+	if corsConfig, ok := cfg.CORS[domain]; ok {
 		return &corsConfig
 	}
 
-	// Check for exact domain match
-	if corsConfig, ok := cfg.CORS[domain]; ok {
+	// Fall back to the wildcard entry
+	if corsConfig, ok := cfg.CORS["*"]; ok {
 		return &corsConfig
 	}
 

--- a/internal/nginx/nginx.go
+++ b/internal/nginx/nginx.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -112,15 +113,19 @@ func (m *Manager) CheckHealth() error {
 	return nil
 }
 
-// getCORSConfig returns the CORS configuration for a given domain.
+// getCORSConfig returns the merged CORS configuration for a given domain.
 //
-// Resolution order (most specific first):
-//  1. Exact domain key (e.g. "api.example.com")
-//  2. Longest matching "*.suffix" wildcard (e.g. "*.api.example.com" wins over
-//     "*.example.com"). A "*.suffix" key matches subdomains only, never the
-//     bare apex — "*.example.com" matches "api.example.com" but not "example.com".
-//  3. The "*" catch-all key
+// Matching layers are applied from lowest to highest priority, so a more
+// specific layer overrides (or clears) fields set by a more general one, while
+// fields it leaves unset are inherited:
 //
+//  1. "*" catch-all (lowest priority)
+//  2. "*.suffix" wildcards, shortest suffix first; "*.suffix" matches subdomains
+//     only — "*.example.com" matches "api.example.com" but not "example.com".
+//  3. Exact domain key (highest priority)
+//
+// A field explicitly set to an empty value ("", null, or []) in a higher layer
+// clears (omits) that header in the result; a field left unset is inherited.
 // This mirrors ssl.FindCertificate's "*.suffix" handling.
 func getCORSConfig(cfg *config.Config, domain string) *config.CORSConfig {
 	if cfg.CORS == nil {
@@ -128,38 +133,77 @@ func getCORSConfig(cfg *config.Config, domain string) *config.CORSConfig {
 	}
 	domain = strings.ToLower(strings.TrimSpace(domain))
 
-	// 1. Exact match (highest priority).
-	if corsConfig, ok := cfg.CORS[domain]; ok {
-		return &corsConfig
+	// Collect applicable layers in priority order (lowest first).
+	var layers []config.CORSConfig
+
+	// 1. Catch-all.
+	if c, ok := cfg.CORS["*"]; ok {
+		layers = append(layers, c)
 	}
 
-	// 2. Longest matching "*.suffix" wildcard.
-	var best *config.CORSConfig
-	var bestLen int
-	for pat, corsConfig := range cfg.CORS {
+	// 2. Matching "*.suffix" wildcards, shortest suffix first.
+	type wildcard struct {
+		suffix string
+		cfg    config.CORSConfig
+	}
+	var wildcards []wildcard
+	for pat, c := range cfg.CORS {
 		if !strings.HasPrefix(pat, "*.") {
 			continue
 		}
 		suffix := pat[1:] // ".example.com"
-		// Match subdomains only: skip the bare apex (pat[2:] == "example.com").
 		if domain != pat[2:] && strings.HasSuffix(domain, suffix) {
-			if best == nil || len(suffix) > bestLen {
-				bestLen = len(suffix)
-				match := corsConfig
-				best = &match
-			}
+			wildcards = append(wildcards, wildcard{suffix, c})
 		}
 	}
-	if best != nil {
-		return best
+	sort.SliceStable(wildcards, func(i, j int) bool {
+		return len(wildcards[i].suffix) < len(wildcards[j].suffix)
+	})
+	for _, w := range wildcards {
+		layers = append(layers, w.cfg)
 	}
 
-	// 3. Catch-all.
-	if corsConfig, ok := cfg.CORS["*"]; ok {
-		return &corsConfig
+	// 3. Exact match (highest priority).
+	if c, ok := cfg.CORS[domain]; ok {
+		layers = append(layers, c)
 	}
 
-	return nil
+	if len(layers) == 0 {
+		return nil
+	}
+
+	// Merge: each layer's explicitly-present fields override the accumulator.
+	merged := config.CORSConfig{}
+	presence := config.CORSFieldPresence{}
+	for _, l := range layers {
+		lp := l.Presence()
+		if lp.AllowOrigin {
+			merged.AllowOrigin = l.AllowOrigin
+			presence.AllowOrigin = true
+		}
+		if lp.AllowMethods {
+			merged.AllowMethods = l.AllowMethods
+			presence.AllowMethods = true
+		}
+		if lp.AllowHeaders {
+			merged.AllowHeaders = l.AllowHeaders
+			presence.AllowHeaders = true
+		}
+		if lp.ExposeHeaders {
+			merged.ExposeHeaders = l.ExposeHeaders
+			presence.ExposeHeaders = true
+		}
+		if lp.MaxAge {
+			merged.MaxAge = l.MaxAge
+			presence.MaxAge = true
+		}
+		if lp.AllowCredentials {
+			merged.AllowCredentials = l.AllowCredentials
+			presence.AllowCredentials = true
+		}
+	}
+	merged.SetPresence(presence)
+	return &merged
 }
 
 // generateCORSHeaders generates CORS header configuration from CORSConfig
@@ -181,41 +225,62 @@ func generateCORSHeaders(corsConfig *config.CORSConfig) string {
             }`
 	}
 
-	// Apply defaults
-	allowOrigin := corsConfig.AllowOrigin
-	if allowOrigin == "" {
-		allowOrigin = "*"
+	// Resolve each header field. A field that was explicitly set to an empty
+	// value ("", null, or []) is cleared (omitted); a field left unset by every
+	// matching layer inherits its default.
+	p := corsConfig.Presence()
+
+	const (
+		defaultMethods = "GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH"
+		defaultHeaders = "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
+		defaultExpose  = "Content-Length,Content-Range"
+	)
+
+	// resolveSlice: present=false → default; present=true+empty → cleared; else join.
+	resolveSlice := func(present bool, parts []string, sep, def string) (string, bool) {
+		if !present {
+			return def, true
+		}
+		if len(parts) == 0 {
+			return "", false
+		}
+		return strings.Join(parts, sep), true
+	}
+	// resolveStr: present=false → default; present=true+"" → cleared; else value.
+	resolveStr := func(present bool, val, def string) (string, bool) {
+		if !present {
+			return def, true
+		}
+		if val == "" {
+			return "", false
+		}
+		return val, true
 	}
 
-	allowMethods := corsConfig.AllowMethods
-	if len(allowMethods) == 0 {
-		allowMethods = []string{"GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"}
-	}
-	methodsStr := strings.Join(allowMethods, ", ")
-
-	allowHeaders := corsConfig.AllowHeaders
-	if len(allowHeaders) == 0 {
-		allowHeaders = []string{"DNT", "User-Agent", "X-Requested-With", "If-Modified-Since", "Cache-Control", "Content-Type", "Range", "Authorization"}
-	}
-	headersStr := strings.Join(allowHeaders, ",")
-
-	exposeHeaders := corsConfig.ExposeHeaders
-	if len(exposeHeaders) == 0 {
-		exposeHeaders = []string{"Content-Length", "Content-Range"}
-	}
-	exposeHeadersStr := strings.Join(exposeHeaders, ",")
+	originVal, emitOrigin := resolveStr(p.AllowOrigin, corsConfig.AllowOrigin, "*")
+	methodsVal, emitMethods := resolveSlice(p.AllowMethods, corsConfig.AllowMethods, ", ", defaultMethods)
+	headersVal, emitHeaders := resolveSlice(p.AllowHeaders, corsConfig.AllowHeaders, ",", defaultHeaders)
+	exposeVal, emitExpose := resolveSlice(p.ExposeHeaders, corsConfig.ExposeHeaders, ",", defaultExpose)
 
 	maxAge := corsConfig.MaxAge
-	if maxAge == 0 {
+	if !p.MaxAge {
 		maxAge = 1728000 // 20 days
 	}
 
 	var sb strings.Builder
 	sb.WriteString("            # CORS configuration\n")
-	sb.WriteString(fmt.Sprintf("            add_header 'Access-Control-Allow-Origin' '%s' always;\n", allowOrigin))
-	sb.WriteString(fmt.Sprintf("            add_header 'Access-Control-Allow-Methods' '%s' always;\n", methodsStr))
-	sb.WriteString(fmt.Sprintf("            add_header 'Access-Control-Allow-Headers' '%s' always;\n", headersStr))
-	sb.WriteString(fmt.Sprintf("            add_header 'Access-Control-Expose-Headers' '%s' always;\n", exposeHeadersStr))
+	if emitOrigin {
+		sb.WriteString(fmt.Sprintf("            add_header 'Access-Control-Allow-Origin' '%s' always;\n", originVal))
+	}
+	if emitMethods {
+		sb.WriteString(fmt.Sprintf("            add_header 'Access-Control-Allow-Methods' '%s' always;\n", methodsVal))
+	}
+	if emitHeaders {
+		sb.WriteString(fmt.Sprintf("            add_header 'Access-Control-Allow-Headers' '%s' always;\n", headersVal))
+	}
+	if emitExpose {
+		sb.WriteString(fmt.Sprintf("            add_header 'Access-Control-Expose-Headers' '%s' always;\n", exposeVal))
+	}
 
 	if corsConfig.AllowCredentials {
 		sb.WriteString("            add_header 'Access-Control-Allow-Credentials' 'true' always;\n")
@@ -223,9 +288,15 @@ func generateCORSHeaders(corsConfig *config.CORSConfig) string {
 
 	sb.WriteString("\n            # Handle OPTIONS preflight requests\n")
 	sb.WriteString("            if ($request_method = 'OPTIONS') {\n")
-	sb.WriteString(fmt.Sprintf("                add_header 'Access-Control-Allow-Origin' '%s' always;\n", allowOrigin))
-	sb.WriteString(fmt.Sprintf("                add_header 'Access-Control-Allow-Methods' '%s' always;\n", methodsStr))
-	sb.WriteString(fmt.Sprintf("                add_header 'Access-Control-Allow-Headers' '%s' always;\n", headersStr))
+	if emitOrigin {
+		sb.WriteString(fmt.Sprintf("                add_header 'Access-Control-Allow-Origin' '%s' always;\n", originVal))
+	}
+	if emitMethods {
+		sb.WriteString(fmt.Sprintf("                add_header 'Access-Control-Allow-Methods' '%s' always;\n", methodsVal))
+	}
+	if emitHeaders {
+		sb.WriteString(fmt.Sprintf("                add_header 'Access-Control-Allow-Headers' '%s' always;\n", headersVal))
+	}
 	if corsConfig.AllowCredentials {
 		sb.WriteString("                add_header 'Access-Control-Allow-Credentials' 'true' always;\n")
 	}

--- a/internal/nginx/nginx.go
+++ b/internal/nginx/nginx.go
@@ -113,14 +113,48 @@ func (m *Manager) CheckHealth() error {
 }
 
 // getCORSConfig returns the CORS configuration for a given domain.
-// A domain-specific entry takes precedence over the "*" wildcard.
+//
+// Resolution order (most specific first):
+//  1. Exact domain key (e.g. "api.example.com")
+//  2. Longest matching "*.suffix" wildcard (e.g. "*.api.example.com" wins over
+//     "*.example.com"). A "*.suffix" key matches subdomains only, never the
+//     bare apex — "*.example.com" matches "api.example.com" but not "example.com".
+//  3. The "*" catch-all key
+//
+// This mirrors ssl.FindCertificate's "*.suffix" handling.
 func getCORSConfig(cfg *config.Config, domain string) *config.CORSConfig {
-	// Check for exact domain match first (most specific wins)
+	if cfg.CORS == nil {
+		return nil
+	}
+	domain = strings.ToLower(strings.TrimSpace(domain))
+
+	// 1. Exact match (highest priority).
 	if corsConfig, ok := cfg.CORS[domain]; ok {
 		return &corsConfig
 	}
 
-	// Fall back to the wildcard entry
+	// 2. Longest matching "*.suffix" wildcard.
+	var best *config.CORSConfig
+	var bestLen int
+	for pat, corsConfig := range cfg.CORS {
+		if !strings.HasPrefix(pat, "*.") {
+			continue
+		}
+		suffix := pat[1:] // ".example.com"
+		// Match subdomains only: skip the bare apex (pat[2:] == "example.com").
+		if domain != pat[2:] && strings.HasSuffix(domain, suffix) {
+			if best == nil || len(suffix) > bestLen {
+				bestLen = len(suffix)
+				match := corsConfig
+				best = &match
+			}
+		}
+	}
+	if best != nil {
+		return best
+	}
+
+	// 3. Catch-all.
 	if corsConfig, ok := cfg.CORS["*"]; ok {
 		return &corsConfig
 	}
@@ -406,9 +440,9 @@ events {
 		}
 	}
 
-	// Collect domains with and without certificates
-	var domainsWithCerts []string
-	var domainsWithoutCerts []string
+	// Build an ordered, de-duplicated list of base domains following the
+	// declaration order of proxy.yaml (cfg.OrderedPorts). This makes server
+	// block emission and the redirect server_name lists deterministic.
 	allDomains := make(map[string]bool)
 	for baseDomain := range domainRoutes {
 		allDomains[baseDomain] = true
@@ -416,7 +450,30 @@ events {
 	for baseDomain := range staticRoutes {
 		allDomains[baseDomain] = true
 	}
-	for baseDomain := range allDomains {
+	var orderedDomains []string
+	seen := make(map[string]bool)
+	for _, key := range cfg.OrderedPorts {
+		for _, domainPath := range cfg.Ports[key] {
+			baseDomain, _ := splitDomainPath(domainPath)
+			if baseDomain == "" || seen[baseDomain] {
+				continue
+			}
+			seen[baseDomain] = true
+			orderedDomains = append(orderedDomains, baseDomain)
+		}
+	}
+	// Defensive fallback: if order info is unavailable, use the map keys so
+	// every configured domain is still emitted.
+	if len(orderedDomains) == 0 {
+		for baseDomain := range allDomains {
+			orderedDomains = append(orderedDomains, baseDomain)
+		}
+	}
+
+	// Collect domains with and without certificates, in declaration order.
+	var domainsWithCerts []string
+	var domainsWithoutCerts []string
+	for _, baseDomain := range orderedDomains {
 		cert, hasCert := ssl.FindCertificate(certMap, baseDomain)
 		if hasCert && cert.KeyPath != "" {
 			domainsWithCerts = append(domainsWithCerts, baseDomain)
@@ -487,8 +544,9 @@ events {
 `)
 	}
 
-	// Generate server blocks for each base domain (combining proxy routes and static routes)
-	for baseDomain := range allDomains {
+	// Generate server blocks for each base domain (combining proxy routes and static routes),
+	// in proxy.yaml declaration order (orderedDomains).
+	for _, baseDomain := range orderedDomains {
 		routes := domainRoutes[baseDomain]
 		staticSiteRoutes := staticRoutes[baseDomain]
 

--- a/internal/nginx/nginx.go
+++ b/internal/nginx/nginx.go
@@ -206,23 +206,19 @@ func getCORSConfig(cfg *config.Config, domain string) *config.CORSConfig {
 	return &merged
 }
 
-// generateCORSHeaders generates CORS header configuration from CORSConfig
+// generateCORSHeaders generates CORS header configuration from CORSConfig.
+//
+// Access-Control-Allow-Origin is emitted ONLY inside the OPTIONS preflight
+// block, never at the location level. Many proxied backends already send this
+// header on actual responses; emitting it at the location level would produce a
+// duplicate ("Access-Control-Allow-Origin cannot contain more than one origin"
+// in the browser). For the preflight the `return 204` short-circuits before
+// proxy_pass, so the backend is never reached and exactly one Origin is sent.
 func generateCORSHeaders(corsConfig *config.CORSConfig) string {
+	// No cors.yaml entry: use built-in defaults via the resolved path below (a
+	// zero-value CORSConfig with no presence falls back to every default).
 	if corsConfig == nil {
-		// Default CORS configuration
-		return `            # CORS configuration
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH' always;
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
-            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
-
-            # Handle OPTIONS preflight requests
-            if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Max-Age' 1728000;
-                add_header 'Content-Type' 'text/plain; charset=utf-8';
-                add_header 'Content-Length' 0;
-                return 204;
-            }`
+		corsConfig = &config.CORSConfig{}
 	}
 
 	// Resolve each header field. A field that was explicitly set to an empty
@@ -269,9 +265,14 @@ func generateCORSHeaders(corsConfig *config.CORSConfig) string {
 
 	var sb strings.Builder
 	sb.WriteString("            # CORS configuration\n")
-	if emitOrigin {
-		sb.WriteString(fmt.Sprintf("            add_header 'Access-Control-Allow-Origin' '%s' always;\n", originVal))
-	}
+	// NOTE: Access-Control-Allow-Origin is intentionally NOT emitted at the
+	// location level. Many proxied backends already send this header on actual
+	// responses; emitting it here would duplicate it and trigger
+	// "Access-Control-Allow-Origin cannot contain more than one origin" in the
+	// browser. Origin is only added inside the OPTIONS preflight block below,
+	// where `return 204` short-circuits before proxy_pass (so the backend is
+	// never reached and there is exactly one Origin). Methods/Headers/Expose
+	// are still emitted here because backends typically don't set those.
 	if emitMethods {
 		sb.WriteString(fmt.Sprintf("            add_header 'Access-Control-Allow-Methods' '%s' always;\n", methodsVal))
 	}
@@ -405,7 +406,7 @@ events {
 
 	// Generate stream block for TCP/UDP if there are any stream mappings
 	if len(streamMappings) > 0 {
-		sb.WriteString(generateStreamBlock(streamMappings, httpPort, httpsPort))
+		sb.WriteString(generateStreamBlock(streamMappings, httpsPort))
 	}
 
 	sb.WriteString(`http {
@@ -556,14 +557,18 @@ events {
 	// Generate default server blocks to handle unconfigured domains
 	sb.WriteString(`    # Default server for HTTP - reject unconfigured domains
     server {
-        listen ` + httpPort + ` default_server;
+        listen `)
+	sb.WriteString(httpPort)
+	sb.WriteString(` default_server;
         server_name _;
         return 444;
     }
 
     # Default server for HTTPS - reject unconfigured domains
     server {
-        listen ` + httpsPort + ` ssl default_server;
+        listen `)
+	sb.WriteString(httpsPort)
+	sb.WriteString(` ssl default_server;
         server_name _;
 
         # Use a dummy self-signed certificate
@@ -582,8 +587,12 @@ events {
 	if len(domainsWithCerts) > 0 {
 		sb.WriteString(`    # HTTP to HTTPS redirect for domains with certificates
     server {
-        listen ` + httpPort + `;
-        server_name ` + strings.Join(domainsWithCerts, " ") + `;
+        listen `)
+		sb.WriteString(httpPort)
+		sb.WriteString(`;
+        server_name `)
+		sb.WriteString(strings.Join(domainsWithCerts, " "))
+		sb.WriteString(`;
 
         location / {
             return 301 https://$host$request_uri;
@@ -597,8 +606,12 @@ events {
 	if len(domainsWithoutCerts) > 0 {
 		sb.WriteString(`    # HTTPS to HTTP redirect for domains without certificates
     server {
-        listen ` + httpsPort + ` ssl;
-        server_name ` + strings.Join(domainsWithoutCerts, " ") + `;
+        listen `)
+		sb.WriteString(httpsPort)
+		sb.WriteString(` ssl;
+        server_name `)
+		sb.WriteString(strings.Join(domainsWithoutCerts, " "))
+		sb.WriteString(`;
 
         # Use a dummy self-signed certificate
         ssl_certificate /etc/nginx/ssl/dummy.crt;
@@ -859,7 +872,7 @@ type StreamMapping struct {
 }
 
 // generateStreamBlock generates the nginx stream block for TCP/UDP forwarding
-func generateStreamBlock(mappings []StreamMapping, httpPort, httpsPort string) string {
+func generateStreamBlock(mappings []StreamMapping, httpsPort string) string {
 	var sb strings.Builder
 	sb.WriteString("stream {\n")
 

--- a/internal/nginx/nginx_test.go
+++ b/internal/nginx/nginx_test.go
@@ -248,6 +248,36 @@ func TestGenerateCORSHeadersDefault(t *testing.T) {
 	}
 }
 
+func TestGenerateCORSHeaders_OriginOnlyInPreflight(t *testing.T) {
+	// Access-Control-Allow-Origin must be emitted ONLY inside the OPTIONS
+	// preflight block (16-space indent), never at the location level
+	// (12-space indent). Otherwise a proxied backend that also sends the
+	// header produces a duplicate on actual responses.
+	out := generateCORSHeaders(&config.CORSConfig{}) // zero value → all defaults
+
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "            add_header 'Access-Control-Allow-Origin'") {
+			t.Fatalf("Allow-Origin must not be emitted at location level, got:\n%s", out)
+		}
+	}
+
+	if !strings.Contains(out, "                add_header 'Access-Control-Allow-Origin' '*' always;") {
+		t.Fatalf("expected Allow-Origin inside OPTIONS block, got:\n%s", out)
+	}
+
+	// The default (nil) path must also produce a complete preflight (with
+	// Origin/Methods/Headers) and no location-level Origin.
+	defOut := generateCORSHeaders(nil)
+	for _, line := range strings.Split(defOut, "\n") {
+		if strings.HasPrefix(line, "            add_header 'Access-Control-Allow-Origin'") {
+			t.Fatalf("default path: Allow-Origin must not be at location level, got:\n%s", defOut)
+		}
+	}
+	if !strings.Contains(defOut, "                add_header 'Access-Control-Allow-Origin' '*' always;") {
+		t.Fatalf("default path: expected Allow-Origin in OPTIONS block, got:\n%s", defOut)
+	}
+}
+
 func TestGenerateConfigHTTPServerBlock(t *testing.T) {
 	cfg := &config.Config{
 		CORS: map[string]config.CORSConfig{},

--- a/internal/nginx/nginx_test.go
+++ b/internal/nginx/nginx_test.go
@@ -65,6 +65,70 @@ func TestGetCORSConfigDomainTakesPrecedenceOverWildcard(t *testing.T) {
 	}
 }
 
+func TestGetCORSConfigSuffixWildcard(t *testing.T) {
+	cfg := &config.Config{CORS: map[string]config.CORSConfig{
+		"*.ibuduan.com": {AllowOrigin: "https://app.ibuduan.com", AllowHeaders: []string{"X-Suffix"}},
+	}}
+
+	// Matches a subdomain.
+	cors := getCORSConfig(cfg, "api.cpu.ibuduan.com")
+	if cors == nil || cors.AllowOrigin != "https://app.ibuduan.com" {
+		t.Fatalf("expected *.ibuduan.com to match subdomain, got %+v", cors)
+	}
+
+	// Does NOT match the bare apex.
+	if got := getCORSConfig(cfg, "ibuduan.com"); got != nil {
+		t.Fatalf("*.ibuduan.com must not match bare apex, got %+v", got)
+	}
+
+	// Does NOT match an unrelated domain.
+	if got := getCORSConfig(cfg, "example.com"); got != nil {
+		t.Fatalf("*.ibuduan.com must not match unrelated domain, got %+v", got)
+	}
+}
+
+func TestGetCORSConfigLongestSuffixWins(t *testing.T) {
+	cfg := &config.Config{CORS: map[string]config.CORSConfig{
+		"*.ibuduan.com":     {AllowHeaders: []string{"short"}},
+		"*.cpu.ibuduan.com": {AllowHeaders: []string{"long"}},
+	}}
+
+	cors := getCORSConfig(cfg, "api.cpu.ibuduan.com")
+	if cors == nil || len(cors.AllowHeaders) != 1 || cors.AllowHeaders[0] != "long" {
+		t.Fatalf("expected longest suffix (*.cpu.ibuduan.com) to win, got %+v", cors)
+	}
+
+	// A subdomain of ibuduan.com that is not under cpu gets the shorter rule.
+	cors = getCORSConfig(cfg, "api.ibuduan.com")
+	if cors == nil || cors.AllowHeaders[0] != "short" {
+		t.Fatalf("expected shorter suffix (*.ibuduan.com), got %+v", cors)
+	}
+}
+
+func TestGetCORSConfigExactBeatsSuffix(t *testing.T) {
+	cfg := &config.Config{CORS: map[string]config.CORSConfig{
+		"*.ibuduan.com":      {AllowHeaders: []string{"suffix"}},
+		"api.cpu.ibuduan.com": {AllowHeaders: []string{"exact"}},
+	}}
+
+	cors := getCORSConfig(cfg, "api.cpu.ibuduan.com")
+	if cors == nil || cors.AllowHeaders[0] != "exact" {
+		t.Fatalf("expected exact key to beat suffix, got %+v", cors)
+	}
+}
+
+func TestGetCORSConfigNoMatch(t *testing.T) {
+	cfg := &config.Config{CORS: map[string]config.CORSConfig{
+		"*.ibuduan.com": {AllowOrigin: "https://app.ibuduan.com"},
+	}}
+	if got := getCORSConfig(cfg, "example.com"); got != nil {
+		t.Fatalf("expected nil for unmatched domain, got %+v", got)
+	}
+	if got := getCORSConfig(&config.Config{}, "anything"); got != nil {
+		t.Fatalf("expected nil for nil CORS map, got %+v", got)
+	}
+}
+
 func TestGenerateCORSHeadersDefault(t *testing.T) {
 	out := generateCORSHeaders(nil)
 	if !strings.Contains(out, "Access-Control-Allow-Origin") {
@@ -93,6 +157,32 @@ func TestGenerateConfigHTTPServerBlock(t *testing.T) {
 	}
 	if !strings.Contains(ng, "proxy_pass http://192.168.1.2:5678/api") {
 		t.Fatalf("expected proxy_pass to upstream with path")
+	}
+}
+
+func TestGenerateConfig_ServerBlocksFollowProxyYAMLOrder(t *testing.T) {
+	// Port keys deliberately non-sorted; OrderedPorts declares the desired order.
+	cfg := &config.Config{
+		CORS: map[string]config.CORSConfig{},
+		Ports: map[string][]string{
+			"3030": {"third.example.com"},
+			"1010": {"first.example.com"},
+			"2020": {"second.example.com"},
+		},
+		OrderedPorts: []string{"1010", "2020", "3030"},
+	}
+
+	ng := GenerateConfig(cfg, nil)
+
+	// Each server block is introduced by a comment naming the base domain.
+	idxFirst := strings.Index(ng, "HTTP server block for first.example.com")
+	idxSecond := strings.Index(ng, "HTTP server block for second.example.com")
+	idxThird := strings.Index(ng, "HTTP server block for third.example.com")
+	if idxFirst < 0 || idxSecond < 0 || idxThird < 0 {
+		t.Fatalf("missing one or more server block markers in:\n%s", ng)
+	}
+	if !(idxFirst < idxSecond && idxSecond < idxThird) {
+		t.Fatalf("server blocks not in OrderedPorts order: first=%d second=%d third=%d", idxFirst, idxSecond, idxThird)
 	}
 }
 

--- a/internal/nginx/nginx_test.go
+++ b/internal/nginx/nginx_test.go
@@ -8,7 +8,19 @@ import (
 
 	"github.com/hnrobert/sslly-nginx/internal/config"
 	"github.com/hnrobert/sslly-nginx/internal/ssl"
+	"gopkg.in/yaml.v3"
 )
+
+// parseCORS parses a YAML CORS map so that per-field presence is recorded (via
+// CORSConfig.UnmarshalYAML), matching how cors.yaml is loaded in production.
+func parseCORS(t *testing.T, yamlStr string) map[string]config.CORSConfig {
+	t.Helper()
+	var m map[string]config.CORSConfig
+	if err := yaml.Unmarshal([]byte(yamlStr), &m); err != nil {
+		t.Fatalf("parse cors yaml: %v", err)
+	}
+	return m
+}
 
 func TestSplitDomainPath(t *testing.T) {
 	domain, path := splitDomainPath("example.com/api")
@@ -33,42 +45,42 @@ func TestFormatUpstreamAddrIPv6(t *testing.T) {
 }
 
 func TestGetCORSConfig(t *testing.T) {
-	cfg := &config.Config{CORS: map[string]config.CORSConfig{"*": {AllowOrigin: "*"}}}
+	cfg := &config.Config{CORS: parseCORS(t, `'*': {allow_origin: '*'}`)}
 	cors := getCORSConfig(cfg, "any.example.com")
 	if cors == nil || cors.AllowOrigin != "*" {
-		t.Fatalf("expected wildcard CORS")
+		t.Fatalf("expected wildcard CORS, got %+v", cors)
 	}
 }
 
 func TestGetCORSConfigDomainTakesPrecedenceOverWildcard(t *testing.T) {
-	cfg := &config.Config{CORS: map[string]config.CORSConfig{
-		"*":              {AllowOrigin: "*", AllowHeaders: []string{"DNT", "User-Agent"}},
-		"api.example.com": {AllowOrigin: "*", AllowHeaders: []string{"*"}},
-	}}
+	cfg := &config.Config{CORS: parseCORS(t, `
+'*':
+  allow_origin: '*'
+  allow_headers: [DNT, User-Agent]
+'api.example.com':
+  allow_origin: '*'
+  allow_headers: ['*']
+`)}
 
 	// Domain-specific entry must win over the wildcard.
 	cors := getCORSConfig(cfg, "api.example.com")
-	if cors == nil {
-		t.Fatalf("expected non-nil CORS for api.example.com")
-	}
-	if len(cors.AllowHeaders) != 1 || cors.AllowHeaders[0] != "*" {
+	if cors == nil || len(cors.AllowHeaders) != 1 || cors.AllowHeaders[0] != "*" {
 		t.Fatalf("expected domain-specific allow_headers [*], got %v", cors.AllowHeaders)
 	}
 
 	// Unrelated domains fall back to the wildcard.
 	other := getCORSConfig(cfg, "other.example.com")
-	if other == nil {
-		t.Fatalf("expected wildcard fallback for other.example.com")
-	}
-	if len(other.AllowHeaders) != 2 || other.AllowHeaders[0] != "DNT" {
+	if other == nil || len(other.AllowHeaders) != 2 || other.AllowHeaders[0] != "DNT" {
 		t.Fatalf("expected wildcard allow_headers, got %v", other.AllowHeaders)
 	}
 }
 
 func TestGetCORSConfigSuffixWildcard(t *testing.T) {
-	cfg := &config.Config{CORS: map[string]config.CORSConfig{
-		"*.ibuduan.com": {AllowOrigin: "https://app.ibuduan.com", AllowHeaders: []string{"X-Suffix"}},
-	}}
+	cfg := &config.Config{CORS: parseCORS(t, `
+'*.ibuduan.com':
+  allow_origin: 'https://app.ibuduan.com'
+  allow_headers: [X-Suffix]
+`)}
 
 	// Matches a subdomain.
 	cors := getCORSConfig(cfg, "api.cpu.ibuduan.com")
@@ -88,44 +100,144 @@ func TestGetCORSConfigSuffixWildcard(t *testing.T) {
 }
 
 func TestGetCORSConfigLongestSuffixWins(t *testing.T) {
-	cfg := &config.Config{CORS: map[string]config.CORSConfig{
-		"*.ibuduan.com":     {AllowHeaders: []string{"short"}},
-		"*.cpu.ibuduan.com": {AllowHeaders: []string{"long"}},
-	}}
+	cfg := &config.Config{CORS: parseCORS(t, `
+'*.ibuduan.com':     {allow_headers: [short]}
+'*.cpu.ibuduan.com': {allow_headers: [long]}
+`)}
 
 	cors := getCORSConfig(cfg, "api.cpu.ibuduan.com")
 	if cors == nil || len(cors.AllowHeaders) != 1 || cors.AllowHeaders[0] != "long" {
-		t.Fatalf("expected longest suffix (*.cpu.ibuduan.com) to win, got %+v", cors)
+		t.Fatalf("expected longest suffix (*.cpu.ibuduan.com) to win, got %+v", cors.AllowHeaders)
 	}
 
 	// A subdomain of ibuduan.com that is not under cpu gets the shorter rule.
 	cors = getCORSConfig(cfg, "api.ibuduan.com")
 	if cors == nil || cors.AllowHeaders[0] != "short" {
-		t.Fatalf("expected shorter suffix (*.ibuduan.com), got %+v", cors)
+		t.Fatalf("expected shorter suffix (*.ibuduan.com), got %+v", cors.AllowHeaders)
 	}
 }
 
 func TestGetCORSConfigExactBeatsSuffix(t *testing.T) {
-	cfg := &config.Config{CORS: map[string]config.CORSConfig{
-		"*.ibuduan.com":      {AllowHeaders: []string{"suffix"}},
-		"api.cpu.ibuduan.com": {AllowHeaders: []string{"exact"}},
-	}}
+	cfg := &config.Config{CORS: parseCORS(t, `
+'*.ibuduan.com':      {allow_headers: [suffix]}
+'api.cpu.ibuduan.com': {allow_headers: [exact]}
+`)}
 
 	cors := getCORSConfig(cfg, "api.cpu.ibuduan.com")
 	if cors == nil || cors.AllowHeaders[0] != "exact" {
-		t.Fatalf("expected exact key to beat suffix, got %+v", cors)
+		t.Fatalf("expected exact key to beat suffix, got %+v", cors.AllowHeaders)
 	}
 }
 
 func TestGetCORSConfigNoMatch(t *testing.T) {
-	cfg := &config.Config{CORS: map[string]config.CORSConfig{
-		"*.ibuduan.com": {AllowOrigin: "https://app.ibuduan.com"},
-	}}
+	cfg := &config.Config{CORS: parseCORS(t, `'*.ibuduan.com': {allow_origin: 'https://app.ibuduan.com'}`)}
 	if got := getCORSConfig(cfg, "example.com"); got != nil {
 		t.Fatalf("expected nil for unmatched domain, got %+v", got)
 	}
 	if got := getCORSConfig(&config.Config{}, "anything"); got != nil {
 		t.Fatalf("expected nil for nil CORS map, got %+v", got)
+	}
+}
+
+func TestGetCORSConfigInheritsUnsetFields(t *testing.T) {
+	// The specific layer sets only allow_credentials; origin/headers must be
+	// inherited from the "*" layer.
+	cfg := &config.Config{CORS: parseCORS(t, `
+'*':
+  allow_origin: 'https://app.example.com'
+  allow_headers: [Content-Type, Authorization]
+'api.example.com':
+  allow_credentials: true
+`)}
+
+	cors := getCORSConfig(cfg, "api.example.com")
+	if cors == nil {
+		t.Fatalf("expected non-nil CORS")
+	}
+	if cors.AllowOrigin != "https://app.example.com" {
+		t.Fatalf("expected inherited origin, got %q", cors.AllowOrigin)
+	}
+	if len(cors.AllowHeaders) != 2 || cors.AllowHeaders[0] != "Content-Type" {
+		t.Fatalf("expected inherited headers, got %v", cors.AllowHeaders)
+	}
+	if !cors.AllowCredentials {
+		t.Fatalf("expected credentials true from specific layer")
+	}
+	// Inherited + explicit fields are both marked present in the merged result.
+	p := cors.Presence()
+	if !p.AllowOrigin || !p.AllowHeaders || !p.AllowCredentials {
+		t.Fatalf("expected origin/headers/credentials present in merge, got %+v", p)
+	}
+}
+
+func TestGetCORSConfigExplicitEmptyClearsField(t *testing.T) {
+	// The specific layer explicitly clears allow_origin with "" and with null.
+	// Both must mark the field present-and-empty (cleared); headers inherit.
+	cfg := &config.Config{CORS: parseCORS(t, `
+'*':
+  allow_origin: '*'
+  allow_headers: [Content-Type]
+'empty.example.com':
+  allow_origin: ''
+'null.example.com':
+  allow_origin:
+`)}
+
+	empty := getCORSConfig(cfg, "empty.example.com")
+	if empty == nil || empty.AllowOrigin != "" || !empty.Presence().AllowOrigin {
+		t.Fatalf("expected cleared (present, empty) origin for empty.example.com, got %+v", empty)
+	}
+	if len(empty.AllowHeaders) != 1 || empty.AllowHeaders[0] != "Content-Type" {
+		t.Fatalf("expected inherited headers, got %v", empty.AllowHeaders)
+	}
+
+	nul := getCORSConfig(cfg, "null.example.com")
+	if nul == nil || nul.AllowOrigin != "" || !nul.Presence().AllowOrigin {
+		t.Fatalf("expected cleared (present, null) origin for null.example.com, got %+v", nul)
+	}
+}
+
+func TestGenerateCORSHeadersClearsAndInherits(t *testing.T) {
+	// A merged config where origin is present+empty (cleared → omit), headers
+	// present (emit), and methods/expose absent (default → emit).
+	merged := &config.CORSConfig{
+		AllowOrigin:  "",
+		AllowHeaders: []string{"X-Inherited"},
+	}
+	merged.SetPresence(config.CORSFieldPresence{AllowOrigin: true, AllowHeaders: true})
+
+	out := generateCORSHeaders(merged)
+	if strings.Contains(out, "Access-Control-Allow-Origin") {
+		t.Fatalf("cleared origin must be omitted, got:\n%s", out)
+	}
+	if !strings.Contains(out, "X-Inherited") {
+		t.Fatalf("expected present header X-Inherited, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Access-Control-Allow-Methods") {
+		t.Fatalf("absent methods should default and be emitted, got:\n%s", out)
+	}
+}
+
+func TestCORSResolutionEndToEnd(t *testing.T) {
+	// User's scenario: "*" sets defaults; specific domain clears allow_origin.
+	cfg := &config.Config{CORS: parseCORS(t, `
+'*':
+  allow_origin: '*'
+  allow_methods: [GET, POST]
+  allow_headers: [Content-Type]
+'api.example.com':
+  allow_origin: ''
+`)}
+
+	out := generateCORSHeaders(getCORSConfig(cfg, "api.example.com"))
+	if strings.Contains(out, "Access-Control-Allow-Origin") {
+		t.Fatalf("origin should be cleared/omitted, got:\n%s", out)
+	}
+	if !strings.Contains(out, "GET, POST") {
+		t.Fatalf("methods should be inherited from *, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Content-Type") {
+		t.Fatalf("headers should be inherited from *, got:\n%s", out)
 	}
 }
 

--- a/internal/nginx/nginx_test.go
+++ b/internal/nginx/nginx_test.go
@@ -40,6 +40,31 @@ func TestGetCORSConfig(t *testing.T) {
 	}
 }
 
+func TestGetCORSConfigDomainTakesPrecedenceOverWildcard(t *testing.T) {
+	cfg := &config.Config{CORS: map[string]config.CORSConfig{
+		"*":              {AllowOrigin: "*", AllowHeaders: []string{"DNT", "User-Agent"}},
+		"api.example.com": {AllowOrigin: "*", AllowHeaders: []string{"*"}},
+	}}
+
+	// Domain-specific entry must win over the wildcard.
+	cors := getCORSConfig(cfg, "api.example.com")
+	if cors == nil {
+		t.Fatalf("expected non-nil CORS for api.example.com")
+	}
+	if len(cors.AllowHeaders) != 1 || cors.AllowHeaders[0] != "*" {
+		t.Fatalf("expected domain-specific allow_headers [*], got %v", cors.AllowHeaders)
+	}
+
+	// Unrelated domains fall back to the wildcard.
+	other := getCORSConfig(cfg, "other.example.com")
+	if other == nil {
+		t.Fatalf("expected wildcard fallback for other.example.com")
+	}
+	if len(other.AllowHeaders) != 2 || other.AllowHeaders[0] != "DNT" {
+		t.Fatalf("expected wildcard allow_headers, got %v", other.AllowHeaders)
+	}
+}
+
 func TestGenerateCORSHeadersDefault(t *testing.T) {
 	out := generateCORSHeaders(nil)
 	if !strings.Contains(out, "Access-Control-Allow-Origin") {


### PR DESCRIPTION
Update CORS logic to prioritize domain-specific entries over wildcards, improve handling with ordered ports support, and implement layer inheritance with field clearing. Adjust header generation to emit `Access-Control-Allow-Origin` only in the OPTIONS preflight block to avoid duplicate headers.